### PR TITLE
missed "{"

### DIFF
--- a/partials/content-wikilinks.html
+++ b/partials/content-wikilinks.html
@@ -1,4 +1,4 @@
-{ $firstBracket := "\\[\\[" }}
+{{ $firstBracket := "\\[\\[" }}
 {{ $lastBracket := "\\]\\]" }}
 
 {{ $wikiregex := "\\[\\[([^/]+?)\\]\\]" }}


### PR DESCRIPTION
A "{" is missed at the beginning.

Thank you for your great work!
Best wishes!